### PR TITLE
Add support for Pipeline Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ dispatched and use the data they provide to perform actions in your application.
 - [x] [Comments Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#comment-events)
 - [x] [Merge request Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#merge-request-events)
 - [ ] [Wiki page Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#wiki-page-events)
-- [ ] [Pipeline Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-events)
+- [x] [Pipeline Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#pipeline-events)
 - [ ] [Job Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events)
 - [ ] [Deployment Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#deployment-events)
 - [ ] [Release Events](https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#group-member-events)

--- a/src/Data/ArtifactsFile.php
+++ b/src/Data/ArtifactsFile.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Spatie\LaravelData\Data;
+
+class ArtifactsFile extends Data
+{
+    public function __construct(
+        public readonly ?string $filename,
+        public readonly ?string $size,
+    ) {
+    }
+}

--- a/src/Data/CiVariable.php
+++ b/src/Data/CiVariable.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Spatie\LaravelData\Data;
+
+class CiVariable extends Data
+{
+    public function __construct(
+        public readonly string $key,
+        public readonly string $value,
+    ) {
+    }
+}

--- a/src/Data/Environment.php
+++ b/src/Data/Environment.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Spatie\LaravelData\Data;
+
+class Environment extends Data
+{
+    public function __construct(
+        public readonly string $name,
+        public readonly string $action,
+        public readonly string $deployment_tier,
+    ) {
+    }
+}

--- a/src/Data/Job.php
+++ b/src/Data/Job.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Carbon\Carbon;
+use Oneduo\LaravelGitlabWebhookClient\Data\Casts\GitlabUTCDatetimeCast;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Data;
+
+class Job extends Data
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $stage,
+        public readonly string $name,
+        #[WithCast(GitlabUTCDatetimeCast::class)]
+        public readonly Carbon $created_at,
+        #[WithCast(GitlabUTCDatetimeCast::class)]
+        public readonly ?Carbon $started_at,
+        #[WithCast(GitlabUTCDatetimeCast::class)]
+        public readonly ?Carbon $finished_at,
+        public readonly float $duration,
+        public readonly float $queued_duration,
+        public readonly ?string $failure_reason,
+        public readonly string $when,
+        public readonly bool $manual,
+        public readonly bool $allow_failure,
+        public readonly User $user,
+        public readonly Runner $runner,
+        public readonly ArtifactsFile $artifacts_file,
+        public readonly ?Environment $environment,
+    ) {
+    }
+}

--- a/src/Data/MergeRequest.php
+++ b/src/Data/MergeRequest.php
@@ -16,22 +16,22 @@ class MergeRequest extends Data
 {
     public function __construct(
         public readonly User $user,
-        public readonly Project $project,
-        public readonly Repository $repository,
+        public readonly ?Project $project,
+        public readonly ?Repository $repository,
         #[DataCollectionOf(Label::class)]
         public readonly ?DataCollection $labels,
         public readonly ?MergeRequestChanges $changes,
         #[DataCollectionOf(User::class)]
         public readonly ?DataCollection $assignees,
 
-        public readonly Project $source,
-        public readonly Project $target,
+        public readonly ?Project $source,
+        public readonly ?Project $target,
         public readonly ?Commit $last_commit,
 
         public readonly int $id,
         public readonly int $iid,
         public readonly ?MergeRequestAction $action,
-        public readonly int $author_id,
+        public readonly ?int $author_id,
         public readonly int $source_project_id,
         public readonly int $target_project_id,
         public readonly string $title,
@@ -56,7 +56,7 @@ class MergeRequest extends Data
         public readonly ?string $state,
         public readonly ?string $target_branch,
         #[WithCast(GitlabUTCDatetimeCast::class)]
-        public readonly Carbon $created_at,
+        public readonly ?Carbon $created_at,
         #[WithCast(GitlabUTCDatetimeCast::class)]
         public readonly ?Carbon $updated_at,
         #[WithCast(GitlabUTCDatetimeCast::class)]

--- a/src/Data/Pipeline.php
+++ b/src/Data/Pipeline.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class Pipeline extends Data
+{
+    public function __construct(
+        public readonly PipelineAttributes $attributes,
+        public readonly ?MergeRequest $merge_request,
+        public readonly User $user,
+        public readonly Project $project,
+        public readonly ?Commit $commit,
+        #[DataCollectionOf(Job::class)]
+        public readonly ?DataCollection $jobs,
+    ) {
+    }
+}

--- a/src/Data/PipelineAttributes.php
+++ b/src/Data/PipelineAttributes.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Carbon\Carbon;
+use Oneduo\LaravelGitlabWebhookClient\Data\Casts\GitlabUTCDatetimeCast;
+use Spatie\LaravelData\Attributes\DataCollectionOf;
+use Spatie\LaravelData\Attributes\WithCast;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelData\DataCollection;
+
+class PipelineAttributes extends Data
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly int $iid,
+        public readonly ?string $name,
+        public readonly ?string $ref,
+        public readonly bool $tag,
+        public readonly ?string $sha,
+        public readonly ?string $before_sha,
+        public readonly ?string $source,
+        public readonly ?string $status,
+        public readonly ?string $detailed_status,
+        /** @var array<string> */
+        public readonly ?array $stages,
+        #[WithCast(GitlabUTCDatetimeCast::class)]
+        public readonly Carbon $created_at,
+        #[WithCast(GitlabUTCDatetimeCast::class)]
+        public readonly Carbon $finished_at,
+        public readonly int $duration,
+        public readonly int $queued_duration,
+        #[DataCollectionOf(CiVariable::class)]
+        public readonly ?DataCollection $variables,
+        public readonly ?string $url,
+    ) {
+    }
+}

--- a/src/Data/Project.php
+++ b/src/Data/Project.php
@@ -11,7 +11,7 @@ class Project extends Data
     public function __construct(
         public readonly ?int $id,
         public readonly ?string $name,
-        public readonly string $url,
+        public readonly ?string $url,
         public readonly ?string $description,
         public readonly ?string $web_url,
         public readonly ?string $avatar_url,

--- a/src/Data/Runner.php
+++ b/src/Data/Runner.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Data;
+
+use Spatie\LaravelData\Data;
+
+class Runner extends Data
+{
+    public function __construct(
+        public readonly int $id,
+        public readonly string $description,
+        public readonly string $runner_type,
+        public readonly bool $active,
+        public readonly bool $is_shared,
+        /** @var array<string> */
+        public readonly ?array $tags,
+    ) {
+    }
+}

--- a/src/Enums/EventType.php
+++ b/src/Enums/EventType.php
@@ -8,6 +8,7 @@ enum EventType: string
 {
     case ISSUE = 'issue';
     case MERGE_REQUEST = 'merge_request';
-    case PUSH = 'push';
     case NOTE = 'note';
+    case PIPELINE = 'pipeline';
+    case PUSH = 'push';
 }

--- a/src/Events/EventFactory.php
+++ b/src/Events/EventFactory.php
@@ -15,8 +15,9 @@ class EventFactory
         $class = match (EventType::tryFrom(data_get($payload, 'object_kind'))) {
             EventType::ISSUE => IssueEvent::class,
             EventType::MERGE_REQUEST => MergeRequestEvent::class,
-            EventType::PUSH => PushEvent::class,
             EventType::NOTE => NoteEvent::class,
+            EventType::PIPELINE => PipelineEvent::class,
+            EventType::PUSH => PushEvent::class,
             default => null,
         };
 

--- a/src/Events/PipelineEvent.php
+++ b/src/Events/PipelineEvent.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Oneduo\LaravelGitlabWebhookClient\Contracts\WebhookEventContract;
+use Oneduo\LaravelGitlabWebhookClient\Data\Pipeline;
+
+class PipelineEvent implements WebhookEventContract
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly string $uuid,
+        public readonly array $headers,
+        public readonly Pipeline $push,
+    ) {
+    }
+
+    public static function build(string $uuid, array $payload, array $headers): self
+    {
+        return new self(
+            uuid: $uuid,
+            headers: $headers,
+            push: Pipeline::from([
+                'attributes' => data_get($payload, 'object_attributes'),
+                'merge_request' => [
+                    'user' => data_get($payload, 'user'),
+                    'project' => data_get($payload, 'project'),
+                    ...data_get($payload, 'merge_request'),
+                ],
+                'user' => data_get($payload, 'user'),
+                'project' => data_get($payload, 'project'),
+                'commit' => data_get($payload, 'commit'),
+                'jobs' => data_get($payload, 'builds'),
+            ]),
+        );
+    }
+}

--- a/tests/Events/IssueEventTest.php
+++ b/tests/Events/IssueEventTest.php
@@ -6,7 +6,7 @@ use Oneduo\LaravelGitlabWebhookClient\Events\IssueEvent;
 it('dispatches an event for IssueEvent', function () {
     Event::fake();
 
-    sendWebhook(__DIR__.'/../fixtures/issue.json')
+    sendWebhook(__DIR__.'/../Fixtures/issue.json')
         ->assertNoContent();
 
     Event::assertDispatched(IssueEvent::class);

--- a/tests/Events/MergeRequestEventTest.php
+++ b/tests/Events/MergeRequestEventTest.php
@@ -8,7 +8,7 @@ use Oneduo\LaravelGitlabWebhookClient\Events\MergeRequestEvent;
 it('dispatches an event for MergeRequestEvent', function () {
     Event::fake();
 
-    sendWebhook(__DIR__.'/../fixtures/mr.json')
+    sendWebhook(__DIR__.'/../Fixtures/mr.json')
         ->assertNoContent();
 
     Event::assertDispatched(MergeRequestEvent::class);

--- a/tests/Events/NoteEventTest.php
+++ b/tests/Events/NoteEventTest.php
@@ -6,7 +6,7 @@ use Oneduo\LaravelGitlabWebhookClient\Events\NoteEvent;
 it('dispatches an event for NoteEvent', function () {
     Event::fake();
 
-    sendWebhook(__DIR__.'/../fixtures/note.json')
+    sendWebhook(__DIR__.'/../Fixtures/note.json')
         ->assertNoContent();
 
     Event::assertDispatched(NoteEvent::class);

--- a/tests/Events/PipelineEventTest.php
+++ b/tests/Events/PipelineEventTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Oneduo\LaravelGitlabWebhookClient\Events\PipelineEvent;
+
+it('dispatches an event for PipelineEvent', function () {
+    Event::fake();
+
+    sendWebhook(__DIR__.'/../Fixtures/pipeline.json')
+        ->assertNoContent();
+
+    Event::assertDispatched(PipelineEvent::class);
+});

--- a/tests/Events/PushEventTest.php
+++ b/tests/Events/PushEventTest.php
@@ -6,7 +6,7 @@ use Oneduo\LaravelGitlabWebhookClient\Events\PushEvent;
 it('dispatches an event for IssueEvent', function () {
     Event::fake();
 
-    sendWebhook(__DIR__.'/../fixtures/push.json')
+    sendWebhook(__DIR__.'/../Fixtures/push.json')
         ->assertNoContent();
 
     Event::assertDispatched(PushEvent::class);

--- a/tests/Events/UnknownEventTest.php
+++ b/tests/Events/UnknownEventTest.php
@@ -12,7 +12,7 @@ it('does not dispatch an event when push type event_type is unknown', function (
         MergeRequestEvent::class,
     ]);
 
-    sendWebhook(__DIR__.'/../fixtures/unknown.json')
+    sendWebhook(__DIR__.'/../Fixtures/unknown.json')
         ->assertServerError();
 
     Event::assertNothingDispatched();

--- a/tests/Fixtures/pipeline.json
+++ b/tests/Fixtures/pipeline.json
@@ -1,0 +1,147 @@
+{
+  "object_kind": "pipeline",
+  "object_attributes": {
+    "id": 1,
+    "iid": 1,
+    "name": null,
+    "ref": "feature/foo",
+    "tag": false,
+    "sha": "167686b0423438194a6a53eb02a1211f565f2e4e",
+    "before_sha": "167686b0423438194a6a53eb02a1211f565f2e4e",
+    "source": "merge_request_event",
+    "status": "running",
+    "detailed_status": "running",
+    "stages": [
+      "Build",
+      "Test"
+    ],
+    "created_at": "2023-08-02 11:21:00 UTC",
+    "finished_at": "2023-08-02 11:44:39 UTC",
+    "duration": 307,
+    "queued_duration": 62,
+    "variables": [
+    ],
+    "url": "http://example.com/foo/bar/-/pipelines/1"
+  },
+  "merge_request": {
+    "id": 1,
+    "iid": 1,
+    "title": "feat: Implement support for Pipeline Events",
+    "source_branch": "feature/foo",
+    "source_project_id": 1,
+    "target_branch": "main",
+    "target_project_id": 1,
+    "state": "opened",
+    "merge_status": "can_be_merged",
+    "detailed_merge_status": "not_approved",
+    "url": "http://example.com/foo/bar/-/merge_requests/14853"
+  },
+  "user": {
+    "id": 1,
+    "name": "John Doe",
+    "username": "jdoe",
+    "avatar_url": null,
+    "email": "john.doe@example.com"
+  },
+  "project": {
+    "id": 1,
+    "name": "bar",
+    "description": "Foo Bar",
+    "web_url": "http://example.com/foo/bar",
+    "avatar_url": "http://example.com/foo/bar/-/avatar",
+    "git_ssh_url": "git@example.com:foo/bar.git",
+    "git_http_url": "http://example.com/foo/bar.git",
+    "namespace": "foo",
+    "visibility_level": 0,
+    "path_with_namespace": "foo/bar",
+    "default_branch": "main",
+    "ci_config_path": ""
+  },
+  "commit": {
+    "id": "167686b0423438194a6a53eb02a1211f565f2e4e",
+    "message": "Implement support for Pipeline Events\n\nLet's support another event!",
+    "title": "Implement support for Pipeline Events",
+    "timestamp": "2023-08-02T11:20:56+00:00",
+    "url": "http://example.com/foo/bar/-/commit/167686b0423438194a6a53eb02a1211f565f2e4e",
+    "author": {
+      "name": "John Doe",
+      "email": "john.doe@example.com"
+    }
+  },
+  "builds": [
+    {
+      "id": 1,
+      "stage": "Build",
+      "name": "build:image:dev",
+      "status": "success",
+      "created_at": "2023-08-02 11:21:00 UTC",
+      "started_at": "2023-08-02 11:22:02 UTC",
+      "finished_at": "2023-08-02 11:22:41 UTC",
+      "duration": 39.19261,
+      "queued_duration": 61.083525,
+      "failure_reason": null,
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user": {
+        "id": 1,
+        "name": "John Doe",
+        "avatar_url": null,
+        "email": "john.doe@example.com"
+      },
+      "runner": {
+        "id": 1,
+        "description": "k8s-ci",
+        "runner_type": "instance_type",
+        "active": true,
+        "is_shared": true,
+        "tags": [
+          "k8s-ci",
+          "kubernetes-ci"
+        ]
+      },
+      "artifacts_file": {
+        "filename": null,
+        "size": null
+      },
+      "environment": null
+    },
+    {
+      "id": 2,
+      "stage": "Test",
+      "name": "test:unit",
+      "status": "success",
+      "created_at": "2023-08-02 11:21:00 UTC",
+      "started_at": "2023-08-02 11:22:42 UTC",
+      "finished_at": "2023-08-02 11:24:02 UTC",
+      "duration": 80.461449,
+      "queued_duration": 0.522503,
+      "failure_reason": null,
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user": {
+        "id": 1,
+        "name": "John Doe",
+        "avatar_url": null,
+        "email": "john.doe@example.com"
+      },
+      "runner": {
+        "id": 263,
+        "description": "k8s-ci",
+        "runner_type": "instance_type",
+        "active": true,
+        "is_shared": true,
+        "tags": [
+          "k8s-ci",
+          "kubernetes-ci"
+        ]
+      },
+      "artifacts_file": {
+        "filename": null,
+        "size": null
+      },
+      "environment": null
+    }
+  ]
+}


### PR DESCRIPTION
This PR provides support for Pipeline Events in Gitlab Webhooks. Besides actual support it contains changes:

- path to fixtures was changed to `Fixtures` because tests were failing on case-sensitive OS
- some properties of existing models were marked as nullable because Pipeline Event's payload contains simplified representation of some sections and creating those models was not possible