### PR TITLE
Allow customising route for handling Gitlab Webhooks

### DIFF
--- a/config/gitlab-webhook-client.php
+++ b/config/gitlab-webhook-client.php
@@ -13,11 +13,36 @@ return [
     | the route in your application and implement the event dispatching logic
     | within your route.
     |
-    | This registers the following route: POST /gitlab-webhook
+    | See "route_path" and "route_name" config options for further customisation.
     |
     | Default: true
     */
     'route_enabled' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook route's path
+    |--------------------------------------------------------------------------
+    |
+    | Here you may choose path under which webhook route is registered.
+    |
+    | This registers the route with POST method under specified path.
+    | Leading path is not required.
+    |
+    | Default: gitlab-webhook
+    */
+    'route_path' => env('GITLAB_WEBHOOK_ROUTE_PATH', 'gitlab-webhook'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Webhook route's name (alias)
+    |--------------------------------------------------------------------------
+    |
+    | Here you may choose name (alias) under which webhook route is registered.
+    |
+    | Default: gitlab-webhook
+    */
+    'route_name' => env('GITLAB_WEBHOOK_ROUTE_NAME', 'gitlab-webhook'),
 
     /*
     |--------------------------------------------------------------------------

--- a/routes/webhook.php
+++ b/routes/webhook.php
@@ -8,7 +8,7 @@ use Oneduo\LaravelGitlabWebhookClient\Http\Middleware\AcceptJsonMiddleware;
 use Oneduo\LaravelGitlabWebhookClient\Http\Middleware\SecretTokenMiddleware;
 
 if (config('gitlab-webhook-client.route_enabled')) {
-    Route::post('gitlab-webhook', WebhookController::class)
+    Route::post(config('gitlab-webhook-client.route_path'), WebhookController::class)
         ->middleware([AcceptJsonMiddleware::class, SecretTokenMiddleware::class])
-        ->name('gitlab-webhook');
+        ->name(config('gitlab-webhook-client.route_name'));
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Testing\TestResponse;
 use Oneduo\LaravelGitlabWebhookClient\Tests\TestCase;
+
 use function Pest\Laravel\postJson;
 
 uses(TestCase::class)->in(__DIR__);
@@ -9,7 +10,7 @@ uses(TestCase::class)->in(__DIR__);
 function sendWebhook(string|array $data, array $headers = [], ?string $hookName = 'Gitlab'): TestResponse
 {
     return postJson(
-        uri: route('gitlab-webhook'),
+        uri: route(config('gitlab-webhook-client.route_name')),
         data: is_string($data) ? json_decode(file_get_contents($data), true) : $data,
         headers: [
             'X-Gitlab-Event-UUID' => fake()->uuid(),


### PR DESCRIPTION
In our current application we already have `gitlab-webhook` route registered, so in order to be able to migrate to your controller we would like to be able to register it under different path (and name), then migrate current logic and in the end go back to default path with your controller. During transition period we can forward requests from current controller to your controller.