### PR TITLE
fix: Jobs' duration and runner may be null

### DIFF
--- a/src/Data/Job.php
+++ b/src/Data/Job.php
@@ -21,8 +21,8 @@ class Job extends Data
         public readonly ?Carbon $started_at,
         #[WithCast(GitlabUTCDatetimeCast::class)]
         public readonly ?Carbon $finished_at,
-        public readonly float $duration,
-        public readonly float $queued_duration,
+        public readonly ?float $duration,
+        public readonly ?float $queued_duration,
         public readonly ?string $failure_reason,
         public readonly string $when,
         public readonly bool $manual,

--- a/src/Data/Job.php
+++ b/src/Data/Job.php
@@ -28,7 +28,7 @@ class Job extends Data
         public readonly bool $manual,
         public readonly bool $allow_failure,
         public readonly User $user,
-        public readonly Runner $runner,
+        public readonly ?Runner $runner,
         public readonly ArtifactsFile $artifacts_file,
         public readonly ?Environment $environment,
     ) {

--- a/src/Data/MergeRequest.php
+++ b/src/Data/MergeRequest.php
@@ -36,6 +36,7 @@ class MergeRequest extends Data
         public readonly int $target_project_id,
         public readonly string $title,
         public readonly string $merge_status,
+        public readonly ?string $merge_commit_sha,
         public readonly string $url,
         public readonly ?array $assignee_ids,
         public readonly ?array $reviewer_ids,

--- a/tests/Fixtures/mr.json
+++ b/tests/Fixtures/mr.json
@@ -58,6 +58,7 @@
     "work_in_progress": false,
     "first_contribution": true,
     "merge_status": "unchecked",
+    "merge_commit_sha": "8668f6c79437988556699424f3a40ec0388be1d6",
     "target_project_id": 14,
     "description": "",
     "total_time_spent": 1800,


### PR DESCRIPTION
While working on event listeners' implementation I've stumbled upon error related to `PipelineEvent`, specifically to `Job` data model. I was using real payloads from our Gitlab instance in Postman and:

- event's object couldn't be created because of `duration`, `queued_duration` and `runner` attributes, that were `null`, so I added nullability
- `merge_commit_sha` was not defined in the `MergeRequest` model, while we use it and need it.