### PR TITLE
Yet another fixes for data models

### DIFF
--- a/src/Data/Job.php
+++ b/src/Data/Job.php
@@ -15,6 +15,7 @@ class Job extends Data
         public readonly int $id,
         public readonly string $stage,
         public readonly string $name,
+        public readonly string $status,
         #[WithCast(GitlabUTCDatetimeCast::class)]
         public readonly Carbon $created_at,
         #[WithCast(GitlabUTCDatetimeCast::class)]

--- a/src/Data/Label.php
+++ b/src/Data/Label.php
@@ -13,7 +13,7 @@ class Label extends Data
 {
     public function __construct(
         public readonly int $id,
-        public readonly int $project_id,
+        public readonly ?int $project_id,
         public readonly bool $template,
         public readonly string $title,
         public readonly ?int $group_id,

--- a/src/Data/MergeRequest.php
+++ b/src/Data/MergeRequest.php
@@ -6,6 +6,7 @@ namespace Oneduo\LaravelGitlabWebhookClient\Data;
 
 use Carbon\Carbon;
 use Oneduo\LaravelGitlabWebhookClient\Data\Casts\GitlabUTCDatetimeCast;
+use Oneduo\LaravelGitlabWebhookClient\Enums\DetailedMergeStatus;
 use Oneduo\LaravelGitlabWebhookClient\Enums\MergeRequestAction;
 use Spatie\LaravelData\Attributes\DataCollectionOf;
 use Spatie\LaravelData\Attributes\WithCast;
@@ -36,6 +37,8 @@ class MergeRequest extends Data
         public readonly int $target_project_id,
         public readonly string $title,
         public readonly string $merge_status,
+        // Introduced in Gitlab 15.6, so can be undefined in older Gitlab instances
+        public readonly ?DetailedMergeStatus $detailed_merge_status,
         public readonly ?string $merge_commit_sha,
         public readonly string $url,
         public readonly ?array $assignee_ids,

--- a/src/Data/PipelineAttributes.php
+++ b/src/Data/PipelineAttributes.php
@@ -29,7 +29,7 @@ class PipelineAttributes extends Data
         #[WithCast(GitlabUTCDatetimeCast::class)]
         public readonly Carbon $created_at,
         #[WithCast(GitlabUTCDatetimeCast::class)]
-        public readonly Carbon $finished_at,
+        public readonly ?Carbon $finished_at,
         public readonly int $duration,
         public readonly int $queued_duration,
         #[DataCollectionOf(CiVariable::class)]

--- a/src/Data/PipelineAttributes.php
+++ b/src/Data/PipelineAttributes.php
@@ -31,7 +31,7 @@ class PipelineAttributes extends Data
         #[WithCast(GitlabUTCDatetimeCast::class)]
         public readonly ?Carbon $finished_at,
         public readonly ?int $duration,
-        public readonly int $queued_duration,
+        public readonly ?int $queued_duration,
         #[DataCollectionOf(CiVariable::class)]
         public readonly ?DataCollection $variables,
         public readonly ?string $url,

--- a/src/Data/PipelineAttributes.php
+++ b/src/Data/PipelineAttributes.php
@@ -30,7 +30,7 @@ class PipelineAttributes extends Data
         public readonly Carbon $created_at,
         #[WithCast(GitlabUTCDatetimeCast::class)]
         public readonly ?Carbon $finished_at,
-        public readonly int $duration,
+        public readonly ?int $duration,
         public readonly int $queued_duration,
         #[DataCollectionOf(CiVariable::class)]
         public readonly ?DataCollection $variables,

--- a/src/Enums/DetailedMergeStatus.php
+++ b/src/Enums/DetailedMergeStatus.php
@@ -6,6 +6,7 @@ namespace Oneduo\LaravelGitlabWebhookClient\Enums;
 
 /**
  * @see https://docs.gitlab.com/ee/api/merge_requests.html#merge-status
+ * @see https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/graphql/types/merge_requests/detailed_merge_status_enum.rb
  */
 enum DetailedMergeStatus: string
 {
@@ -22,5 +23,6 @@ enum DetailedMergeStatus: string
     case NOT_APPROVED = 'not_approved';
     case NOT_OPEN = 'not_open';
     case POLICIES_DENIED = 'policies_denied';
+    case PREPARING = 'preparing';
     case UNCHECKED = 'unchecked';
 }

--- a/src/Enums/DetailedMergeStatus.php
+++ b/src/Enums/DetailedMergeStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Oneduo\LaravelGitlabWebhookClient\Enums;
+
+/**
+ * @see https://docs.gitlab.com/ee/api/merge_requests.html#merge-status
+ */
+enum DetailedMergeStatus: string
+{
+    case BLOCKED_STATUS = 'blocked_status';
+    case BROKEN_STATUS = 'broken_status';
+    case CHECKING = 'checking';
+    case CI_MUST_PASS = 'ci_must_pass';
+    case CI_STILL_RUNNING = 'ci_still_running';
+    case DISCUSSIONS_NOT_RESOLVED = 'discussions_not_resolved';
+    case DRAFT_STATUS = 'draft_status';
+    case EXTERNAL_STATUS_CHECKS = 'external_status_checks';
+    case JIRA_ASSOCIATION_MISSING = 'jira_association_missing';
+    case MERGEABLE = 'mergeable';
+    case NOT_APPROVED = 'not_approved';
+    case NOT_OPEN = 'not_open';
+    case POLICIES_DENIED = 'policies_denied';
+    case UNCHECKED = 'unchecked';
+}

--- a/src/Events/PipelineEvent.php
+++ b/src/Events/PipelineEvent.php
@@ -26,11 +26,11 @@ class PipelineEvent implements WebhookEventContract
             headers: $headers,
             pipeline: Pipeline::from([
                 'attributes' => data_get($payload, 'object_attributes'),
-                'merge_request' => [
+                'merge_request' => isset($payload['merge_request']) ? [
                     'user' => data_get($payload, 'user'),
                     'project' => data_get($payload, 'project'),
                     ...data_get($payload, 'merge_request'),
-                ],
+                ] : null,
                 'user' => data_get($payload, 'user'),
                 'project' => data_get($payload, 'project'),
                 'commit' => data_get($payload, 'commit'),

--- a/src/Events/PipelineEvent.php
+++ b/src/Events/PipelineEvent.php
@@ -15,7 +15,7 @@ class PipelineEvent implements WebhookEventContract
     public function __construct(
         public readonly string $uuid,
         public readonly array $headers,
-        public readonly Pipeline $push,
+        public readonly Pipeline $pipeline,
     ) {
     }
 
@@ -24,7 +24,7 @@ class PipelineEvent implements WebhookEventContract
         return new self(
             uuid: $uuid,
             headers: $headers,
-            push: Pipeline::from([
+            pipeline: Pipeline::from([
                 'attributes' => data_get($payload, 'object_attributes'),
                 'merge_request' => [
                     'user' => data_get($payload, 'user'),


### PR DESCRIPTION
- Support for `detailed_merge_status` in Merge Request event
- Proper name for pipeline property in `PipelineEvent` (it was me who named it like that 🤦)
- Pipeline event not necessarily is related to Merge Request (allow `merge_request: null`)
- `PipelineAttributes::$finished_at` can be null (when pipeline is running)
- `PipelineAttributes::$duration` can be null (when pipeline is running)
- `PipelineAttributes::$queued_duration` can be null (when pipeline is running)
- `Label::$project_id` can be null, when label is a project group's label (defined for all projects in a group)