### PR TITLE
Update Gitlab models

### DIFF
--- a/src/Data/CiVariable.php
+++ b/src/Data/CiVariable.php
@@ -10,7 +10,7 @@ class CiVariable extends Data
 {
     public function __construct(
         public readonly string $key,
-        public readonly string $value,
+        public readonly ?string $value = null,
     ) {
     }
 }

--- a/src/Enums/DetailedMergeStatus.php
+++ b/src/Enums/DetailedMergeStatus.php
@@ -15,6 +15,7 @@ enum DetailedMergeStatus: string
     case CHECKING = 'checking';
     case CI_MUST_PASS = 'ci_must_pass';
     case CI_STILL_RUNNING = 'ci_still_running';
+    case CONFLICT = 'conflict';
     case DISCUSSIONS_NOT_RESOLVED = 'discussions_not_resolved';
     case DRAFT_STATUS = 'draft_status';
     case EXTERNAL_STATUS_CHECKS = 'external_status_checks';


### PR DESCRIPTION
Hi, here are additional fixes required to work with newest Gitlab. We encountered such values in our PROD integration (Gitlab 16.11).

- `CiVariable`'s value can be null
- Support `conflict` detailed merge status