### PR TITLE
Add missing enum values for detailed Merge Request status

### DIFF
--- a/src/Enums/DetailedMergeStatus.php
+++ b/src/Enums/DetailedMergeStatus.php
@@ -10,21 +10,27 @@ namespace Oneduo\LaravelGitlabWebhookClient\Enums;
  */
 enum DetailedMergeStatus: string
 {
+    case APPROVALS_SYNCING = 'approvals_syncing';
     case BLOCKED_STATUS = 'blocked_status';
     case BROKEN_STATUS = 'broken_status';
     case CHECKING = 'checking';
     case CI_MUST_PASS = 'ci_must_pass';
     case CI_STILL_RUNNING = 'ci_still_running';
+    case COMMITS_STATUS = 'commits_status';
     case CONFLICT = 'conflict';
     case DISCUSSIONS_NOT_RESOLVED = 'discussions_not_resolved';
     case DRAFT_STATUS = 'draft_status';
     case EXTERNAL_STATUS_CHECKS = 'external_status_checks';
     case JIRA_ASSOCIATION_MISSING = 'jira_association_missing';
+    case LOCKED_PATHS = 'locked_paths';
+    case LOCKED_LFS_FILES = 'locked_lfs_files';
     case MERGEABLE = 'mergeable';
     case MERGE_REQUEST_BLOCKED = 'merge_request_blocked';
+    case NEED_REBASE = 'need_rebase';
     case NOT_APPROVED = 'not_approved';
     case NOT_OPEN = 'not_open';
     case POLICIES_DENIED = 'policies_denied';
     case PREPARING = 'preparing';
+    case SECURITY_POLICIES_EVALUATING = 'security_policy_evaluation';
     case UNCHECKED = 'unchecked';
 }

--- a/src/Enums/DetailedMergeStatus.php
+++ b/src/Enums/DetailedMergeStatus.php
@@ -31,6 +31,7 @@ enum DetailedMergeStatus: string
     case NOT_OPEN = 'not_open';
     case POLICIES_DENIED = 'policies_denied';
     case PREPARING = 'preparing';
+    case REQUESTED_CHANGES = 'requested_changes';
     case SECURITY_POLICIES_EVALUATING = 'security_policy_evaluation';
     case UNCHECKED = 'unchecked';
 }


### PR DESCRIPTION
Recently our webhook started to throw error 500 again, it's a little bit unfortunate that external enum, which is out of control of this package, can affect production systems because of newly added values... Maybe it should be considered to fallback to `string` value if enum can't be created? All in all, the value sent by Gitlab to the webhook endpoint _has to be correct_ 😅. Maybe enums like [`detailed_merge_status_enum.rb`](https://gitlab.com/gitlab-org/gitlab/-/blob/master/app/graphql/types/merge_requests/detailed_merge_status_enum.rb) should be parsed in a scheduled job and compared with package's enum, so it would fail early and could be fixed instantly?