### PR TITLE
Deployment tier can be null

### DIFF
--- a/src/Data/Environment.php
+++ b/src/Data/Environment.php
@@ -11,6 +11,6 @@ class Environment extends Data
     public function __construct(
         public readonly string $name,
         public readonly string $action,
-        public readonly string $deployment_tier,
+        public readonly ?string $deployment_tier,
     ) {}
 }


### PR DESCRIPTION
After latest Gitlab update we encountered such error:

```
Oneduo\LaravelGitlabWebhookClient\Data\Environment::__construct(): Argument #3 ($deployment_tier) must be of type string, null given
```

This PR make `$deployment_tier` nullable to fix the issue.