### PR TITLE
fix: Job stage can be null

### DIFF
--- a/src/Data/Job.php
+++ b/src/Data/Job.php
@@ -13,7 +13,7 @@ class Job extends Data
 {
     public function __construct(
         public readonly int $id,
-        public readonly string $stage,
+        public readonly ?string $stage,
         public readonly string $name,
         public readonly string $status,
         #[WithCast(GitlabUTCDatetimeCast::class)]


### PR DESCRIPTION
From our production webhooks:

```
Oneduo\LaravelGitlabWebhookClient\Data\Job::__construct(): Argument #2 ($stage) must be of type string, null given, called in /app/vendor/spatie/laravel-data/src/Resolvers/DataFromArrayResolver.php on line 79
```

on Gitlab Premium 17.8. It doesn't make much sense to be honest, as all jobs have stage (verified in Gitlab's Pipeline Editor), but I see the webhook's payload in Sentry and all jobs under `builds` field really have `"stage": null` 🤷. Found [related topic on Gitlab's forum](https://forum.gitlab.com/t/possible-bug-webhooks-containing-jobs-with-null-stage-name/102417).