### PR TITLE
Improve QA suite

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,12 @@
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
-        "format": "vendor/bin/pint"
+        "format": "vendor/bin/pint",
+        "qa": [
+            "@analyse",
+            "@test",
+            "@format"
+        ]
     },
     "config": {
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
     "scripts": {
         "post-autoload-dump": "@php ./vendor/bin/testbench package:discover --ansi",
         "analyse": "vendor/bin/phpstan analyse",
+        "analyse:baseline": "vendor/bin/phpstan analyse --generate-baseline=phpstan-baseline.neon",
         "test": "vendor/bin/pest",
         "test-coverage": "vendor/bin/pest --coverage",
         "format": "vendor/bin/pint",

--- a/composer.json
+++ b/composer.json
@@ -23,15 +23,16 @@
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^7.9",
-        "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^8.0",
-        "pestphp/pest": "^2.0",
-        "pestphp/pest-plugin-arch": "^2.0",
-        "pestphp/pest-plugin-laravel": "^2.0",
+        "nunomaduro/collision": "^8.6",
+        "nunomaduro/larastan": "^3.0.2",
+        "orchestra/testbench": "^9.0",
+        "pestphp/pest": "^3.7",
+        "pestphp/pest-plugin-arch": "^3.0",
+        "pestphp/pest-plugin-laravel": "^3.1",
         "phpstan/extension-installer": "^1.1",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-phpunit": "^1.0"
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-phpunit": "^2.0",
+        "spatie/laravel-ray": "^1.26"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+    'message' => '#^Called \'env\' outside of the config directory which returns null when the config is cached, use \'config\'\\.$#',
+    'identifier' => 'larastan.noEnvCallsOutsideOfConfig',
+    'count' => 3,
+    'path' => __DIR__.'/config/gitlab-webhook-client.php',
+];
+$ignoreErrors[] = [
+    'message' => '#^Call to an undefined method Pest\\\\PendingCalls\\\\TestCall\\:\\:expect\\(\\)\\.$#',
+    'identifier' => 'method.notFound',
+    'count' => 1,
+    'path' => __DIR__.'/tests/ArchTest.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,11 +4,11 @@ includes:
 parameters:
     level: 4
     paths:
-        - src
         - config
-        - database
+        - routes
+        - src
+        - tests
     tmpDir: build/phpstan
     checkOctaneCompatibility: true
     checkModelProperties: true
-    checkMissingIterableValueType: false
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 includes:
-    - phpstan-baseline.neon
+    - phpstan-baseline.php
 
 parameters:
     level: 4


### PR DESCRIPTION
This PR fixes PHPStan config and improves QA process in general (by bumping dev dependencies, fixing issues reported by Composer scripts etc). I don't know why `.github/workflows/fix-php-code-style-issues.yml` and `.github/workflows/phpstan.yml` workflows are skipped in GH Actions (are they disabled for this repo?), but these were failing before. Anyway, dev working with this repo should run `composer qa` before committing and all checks have to pass.