### PR TITLE
Add missing `merge_time` detailed merge status

### DIFF
--- a/src/Enums/DetailedMergeStatus.php
+++ b/src/Enums/DetailedMergeStatus.php
@@ -26,6 +26,7 @@ enum DetailedMergeStatus: string
     case LOCKED_LFS_FILES = 'locked_lfs_files';
     case MERGEABLE = 'mergeable';
     case MERGE_REQUEST_BLOCKED = 'merge_request_blocked';
+    case MERGE_TIME = 'merge_time';
     case NEED_REBASE = 'need_rebase';
     case NOT_APPROVED = 'not_approved';
     case NOT_OPEN = 'not_open';


### PR DESCRIPTION
Related to a MR setting that was recently added:

<img width="264" alt="image" src="https://github.com/user-attachments/assets/f471db4e-0673-49db-9034-b318f0ba2231" />
